### PR TITLE
Add files via upload

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -425,42 +425,6 @@ vector<AddressSpace::SyscallType> AddressSpace::rr_page_syscalls() {
   return result;
 }
 
-template <typename Arch> static vector<uint8_t> read_auxv_arch(Task* t) {
-  auto stack_ptr = t->regs().sp().cast<typename Arch::unsigned_word>();
-
-  auto argc = t->read_mem(stack_ptr);
-  stack_ptr += argc + 1;
-
-  // Check final NULL in argv
-  auto null_ptr = t->read_mem(stack_ptr);
-  ASSERT(t, null_ptr == 0);
-  stack_ptr++;
-
-  // Should now point to envp
-  while (0 != t->read_mem(stack_ptr)) {
-    stack_ptr++;
-  }
-  stack_ptr++;
-  // should now point to ELF Auxiliary Table
-
-  vector<uint8_t> result;
-  while (true) {
-    auto pair_vec = t->read_mem(stack_ptr, 2);
-    stack_ptr += 2;
-    typename Arch::unsigned_word pair[2] = { pair_vec[0], pair_vec[1] };
-    result.resize(result.size() + sizeof(pair));
-    memcpy(result.data() + result.size() - sizeof(pair), pair, sizeof(pair));
-    if (pair[0] == 0) {
-      break;
-    }
-  }
-  return result;
-}
-
-static vector<uint8_t> read_auxv(Task* t) {
-  RR_ARCH_FUNCTION(read_auxv_arch, t->arch(), t);
-}
-
 void AddressSpace::save_auxv(Task* t) { saved_auxv_ = read_auxv(t); }
 
 void AddressSpace::post_exec_syscall(Task* t) {

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,13 @@ class TraceFrame;
 enum Completion { COMPLETE, INCOMPLETE };
 
 /**
+ * returns a vector containing the data you can get from getauxval
+ * it would be cool, if we implemented a real interface to get the remote 
+ * auxiliary  vector
+ */
+std::vector<uint8_t> read_auxv(Task* t);
+
+/**
  * Create a file named |filename| and dump |buf_len| words in |buf| to
  * that file, starting with a line containing |label|.  |start_addr|
  * is the client address at which |buf| resides, if meaningful.


### PR DESCRIPTION
Fix for issue #2207 
I put the `read_auxv()` function from `AddressSpace.cc` to `util.cc`, so we can access the function from `record_syscall.cc`, too. 
For now, we get the `exe_entry` by looking for the correct bytes according to the underlying `arch()` which are magic numbers defined in `record_syscall.cc`.
I didn't compiled rr for x86_64 architectures, if this happens not automatically. I tested for x86 and x86_64 tracee's and the mapping worked. 
Maybe it would be cool, if we implement something like `remote_getauxval(...)` to get the tracee's auxiliary values in a clean way. What would be the correct class (or file) to implement such a function?
In that way, we can define all the magic numbers needed to get the auxiliary vector, not only the AT_ENTRY value.